### PR TITLE
Resolve two cases of invalid memory access

### DIFF
--- a/src/PanelBoard.cpp
+++ b/src/PanelBoard.cpp
@@ -410,7 +410,11 @@ void PanelBoard::BlackClock( const wxString &txt, bool red )
 
 void PanelBoard::SetBoardTitle()
 {
-	SetBoardTitle( m_title_saved.c_str() );
+	// this is needed because SetBoardTitle(const char*)
+	// sets m_title_saved which destroys the results of c_str()
+	// but that function assumes the pointer is not deleted
+	std::string title = m_title_saved;
+	SetBoardTitle( title.c_str() );
 }
 
 void PanelBoard::SetBoardTitle( const char *txt )

--- a/src/thc.h
+++ b/src/thc.h
@@ -348,17 +348,10 @@ public:
     }
 
     // Copy constructor
-    ChessPosition( const ChessPosition& src )
-    {
-        memcpy( (void*)this, (void*)&src, sizeof(ChessPosition) );
-    }
+    ChessPosition( const ChessPosition& src ) = default;
 
     // Assignment operator
-    ChessPosition& operator=( const ChessPosition& src )
-    {
-        memcpy( (void*)this, (void*)&src, sizeof(ChessPosition) );
-        return( *this );
-    }
+    ChessPosition& operator=( const ChessPosition& src ) = default;
 
     // Equality operator
     bool operator ==( const ChessPosition &other ) const


### PR DESCRIPTION
While bored tonight I ran some static analysis on the code and found two issues that I was able to address. PanelBoard::SetBoardTitle() causes invalid pointers to be read. 

void PanelBoard::SetBoardTitle()
{
  SetBoardTitle( m_title_saved.c_str() );
}

SetBoardTitle(const char*) then assigns its parameter to a new std::string and then assigns that string to m_title_saved which invalidates the parameter. It then proceeds to reference the invalidated parameter despite it being invalidated by the assignment operator to m_title_saved. 

The static analyzer also uncovered that memcpy was being used to initialize and/or copy objects that have vtables. In general this is only valid if the underlying object that meets the requirements of https://en.cppreference.com/w/cpp/named_req/StandardLayoutType which can be tested by using std::is_standard_layout. I defaulted those operators and tested the code; It appears to work with the defaults.